### PR TITLE
New L3 communication objective: abstraction level

### DIFF
--- a/frameworks/engineering/backend.md
+++ b/frameworks/engineering/backend.md
@@ -143,6 +143,10 @@ Check out the original backend engineering framework [here](https://eng-progress
 
 - Considers the opinions of others before defending their own
 
+- Speaks and writes at the level of abstraction of their audience
+
+ 	- Determines how familiar their audience is with the problem at hand, and avoids or explains jargon they may not be familiar with. Considers their audience's use of time in written communication: a message is written once but may be read several times.
+
 ### Leadership
 - Onboards / mentors new engineers
 


### PR DESCRIPTION
There is a similar L5 objective: "Talks to non-technical stakeholders on appropriate level of abstraction". Two issues with this:

1. Engineers at Monzo are constantly working with non-technical, or "semi-technical" stakeholders. We have to explain to COps how features work, and work closely with Design, Legal, Marketing etc. Do we really want only L5 and L6 to be incentivised to work on how they communicate with non-engineers?

2. It's not just about comms with non-engineers: an engineer in the Payments team talking to an engineer in Growth about faster payments should bear in mind that their peer in Growth is unlikely to have the same level of detailed knowledge of how it works, and should tailor their comms accordingly.